### PR TITLE
Requests failing. Updates User-Agent due to rate limit response 

### DIFF
--- a/lib/yf_as_dataframe/version.rb
+++ b/lib/yf_as_dataframe/version.rb
@@ -1,3 +1,3 @@
 class YfAsDataframe
-  VERSION = "0.2.15"
+  VERSION = "0.3.0"
 end

--- a/lib/yf_as_dataframe/yf_connection.rb
+++ b/lib/yf_as_dataframe/yf_connection.rb
@@ -15,7 +15,7 @@ class YfAsDataframe
     # Have one place to retrieve data from Yahoo API in order to ease caching and speed up operations.
     # """
     @@user_agent_headers = {
-      'User-Agent' => 'Mozilla/5.0 (Macintosh; Intel Mac OS X 10_10_1) AppleWebKit/537.36 (KHTML, like Gecko) Chrome/39.0.2171.95 Safari/537.36'
+      'User-Agent' => 'Mozilla/5.0 (Macintosh; Intel Mac OS X 10_15_7) AppleWebKit/537.36 (KHTML, like Gecko) Chrome/133.0.0.0 Safari/537.36'
       # 'Mozilla/5.0 (Macintosh; Intel Mac OS X 10_15_7) AppleWebKit/537.36 (KHTML, like Gecko) Chrome/125.0.0.0 Safari/537.36'
     }
     @@proxy = nil


### PR DESCRIPTION
When making a request to YF Api, results started erroring out: 

example: 

```
NoMethodError: undefined method `[]' for nil (NoMethodError)

      result["quoteSummary"]["result"][0]["symbol"] = symbol
                                      ^^^
from <<REDACTED-PATH>>/gems/yf_as_dataframe-0.2.15/lib/yf_as_dataframe/quote.rb:269:in `_fetch_info'
```

Underlying result returns: 
```
 result
=> "Edge: Too Many Requests"
```

Changing the User Agent makes it happy again.  

I'm not sure if Yahoo Finance started blocking that or rate limiting it or what, but this gets it working again