### PR TITLE
Add GitHub Actions CI workflow

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -17,7 +17,9 @@ jobs:
         uses: ruby/setup-ruby@v1
         with:
           ruby-version: '3.3'
-          bundler-cache: true
+      
+      - name: Install dependencies
+        run: bundle install
       
       - name: Run RuboCop
         run: bundle exec rake

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -1,0 +1,23 @@
+name: CI
+
+on:
+  push:
+    branches:
+      - master
+  pull_request:
+
+jobs:
+  lint:
+    runs-on: ubuntu-latest
+    
+    steps:
+      - uses: actions/checkout@v4
+      
+      - name: Set up Ruby
+        uses: ruby/setup-ruby@v1
+        with:
+          ruby-version: '3.3'
+          bundler-cache: true
+      
+      - name: Run RuboCop
+        run: bundle exec rake

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -18,6 +18,9 @@ jobs:
         with:
           ruby-version: '3.3'
       
+      - name: Add current platform to lockfile
+        run: bundle lock --add-platform x86_64-linux
+      
       - name: Install dependencies
         run: bundle install
       

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -50,15 +50,11 @@ GEM
       bigdecimal (~> 3.1)
     nokogiri (1.18.8-arm64-darwin)
       racc (~> 1.4)
-    nokogiri (1.18.8-x86_64-linux)
-      racc (~> 1.4)
     parallel (1.27.0)
     parser (3.3.8.0)
       ast (~> 2.4.1)
       racc
     polars-df (0.12.0-arm64-darwin)
-      bigdecimal
-    polars-df (0.12.0-x86_64-linux)
       bigdecimal
     prism (1.4.0)
     racc (1.8.1)
@@ -93,7 +89,6 @@ GEM
 
 PLATFORMS
   arm64-darwin-23
-  x86_64-linux
 
 DEPENDENCIES
   rake (~> 13.0)

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -50,11 +50,15 @@ GEM
       bigdecimal (~> 3.1)
     nokogiri (1.18.8-arm64-darwin)
       racc (~> 1.4)
+    nokogiri (1.18.8-x86_64-linux)
+      racc (~> 1.4)
     parallel (1.27.0)
     parser (3.3.8.0)
       ast (~> 2.4.1)
       racc
     polars-df (0.12.0-arm64-darwin)
+      bigdecimal
+    polars-df (0.12.0-x86_64-linux)
       bigdecimal
     prism (1.4.0)
     racc (1.8.1)
@@ -89,6 +93,7 @@ GEM
 
 PLATFORMS
   arm64-darwin-23
+  x86_64-linux
 
 DEPENDENCIES
   rake (~> 13.0)


### PR DESCRIPTION
<!-- CURSOR_AGENT_PR_BODY_BEGIN -->
This PR adds a GitHub Actions CI workflow to run automated checks on pull requests and pushes to the master branch.

## Changes

- Creates `.github/workflows/ci.yml` that runs on `pull_request` and `push` to `master`
- Installs Ruby 3.3 (satisfies the gem's requirement of >= 3.0.0)
- Handles platform-specific gems by running `bundle lock --add-platform x86_64-linux` before installing dependencies
- Runs `bundle exec rake` which executes RuboCop linting (the repository's current default task)

## Notes

This repository does not currently have a test suite (no `spec/` or `test/` directories). The workflow runs the existing validation mechanism: RuboCop linting via the default rake task.

The workflow uses:
- `ruby/setup-ruby@v1` for Ruby installation
- Ruby 3.3 as a stable, current version that meets the gemspec requirement
- `bundle lock --add-platform` to support both macOS ARM and Linux x86_64 platforms
- Standard GitHub Actions environment (ubuntu-latest)

## CI Status

The workflow is functioning correctly. Current runs detect RuboCop style offenses in the codebase (2,823 offenses), which is expected behavior for linting checks.
<!-- CURSOR_AGENT_PR_BODY_END -->

<div><a href="https://cursor.com/agents/bc-3ac6fd7a-8ab2-40cb-bb30-d7c1baaff0b8?cursor_ref=pr_footer&cursor_cta=open_in_web"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-web-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-web-light.png"><img alt="Open in Web" width="114" height="28" src="https://cursor.com/assets/images/open-in-web-dark.png"></picture></a>&nbsp;<a href="https://cursor.com/background-agent?bcId=bc-3ac6fd7a-8ab2-40cb-bb30-d7c1baaff0b8&cursor_ref=pr_footer&cursor_cta=open_in_cursor"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-cursor-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-cursor-light.png"><img alt="Open in Cursor" width="131" height="28" src="https://cursor.com/assets/images/open-in-cursor-dark.png"></picture></a>&nbsp;</div>

