### PR TITLE
Bump version to 0.5.0

### DIFF
--- a/README.md
+++ b/README.md
@@ -30,6 +30,11 @@ Yahoo! finance API is intended for personal use only.**
 
 This package provides for pulling data from Yahoo!'s unofficial API, and providing that data using using [Polars](https://github.com/ankane/ruby-polars?tab=readme-ov-file) dataframes in ruby.  Data in those dataframes can then be easily post-processed using technical indicators provided by [Tulip](https://tulipindicators.org/) via [Tulirb's](https://www.rubydoc.info/github/ozone4real/tulirb/main/Tulirb) ruby bindings, and visualized using [Vega](https://github.com/ankane/vega-ruby). 
 
+## Requirements
+
+- **Ruby**: >= 3.3
+- **polars-df**: 0.27.1
+
 ### Quick Start: The Ticker module
 
 The `Ticker` class, which allows you to access ticker data from Yahoo!'s unofficial API:
@@ -384,7 +389,7 @@ The test suite covers:
 - **Technical Indicators**: SMA, EMA, RSI, OBV, and other price technical indicators
 - **Error Handling**: Invalid symbols, network failures, and malformed responses
 
-Tests are designed to run offline using fixtures, avoiding live network requests and ensuring consistent, fast test execution in CI environments.
+Tests are designed to run offline using fixtures, avoiding live network requests and ensuring consistent, fast test execution.
 
 ---
 

--- a/lib/yf_as_dataframe/version.rb
+++ b/lib/yf_as_dataframe/version.rb
@@ -1,3 +1,3 @@
 class YfAsDataframe
-  VERSION = "0.4.1"
+  VERSION = "0.5.0"
 end


### PR DESCRIPTION
<!-- CURSOR_AGENT_PR_BODY_BEGIN -->
This PR bumps the gem version from 0.4.1 to 0.5.0 to prepare for the next release.

## Changes
- Updated `YfAsDataframe::VERSION` to "0.5.0" in `lib/yf_as_dataframe/version.rb`
- Added Requirements section to README.md (Ruby >= 3.3, polars-df 0.27.1)
- Removed CI/GitHub Actions references from Testing section in README.md

## Version Notes
This minor version bump reflects:
- Required Ruby version >= 3.3
- Polars-df 0.27.1 dependency
- Test suite improvements and documentation updates already on master

## Testing
All tests pass: 39 examples, 0 failures, 7 pending (expected Ticker#history specs)
<!-- CURSOR_AGENT_PR_BODY_END -->

<div><a href="https://cursor.com/agents/bc-dce0f13a-13ed-4ec3-a9cb-88423716e1f3?cursor_ref=pr_footer&cursor_cta=open_in_web"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-web-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-web-light.png"><img alt="Open in Web" width="114" height="28" src="https://cursor.com/assets/images/open-in-web-dark.png"></picture></a>&nbsp;<a href="https://cursor.com/background-agent?bcId=bc-dce0f13a-13ed-4ec3-a9cb-88423716e1f3&cursor_ref=pr_footer&cursor_cta=open_in_cursor"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-cursor-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-cursor-light.png"><img alt="Open in Cursor" width="131" height="28" src="https://cursor.com/assets/images/open-in-cursor-dark.png"></picture></a>&nbsp;</div>

